### PR TITLE
Add "Assert Nil" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,21 @@ gem install rouge
 ----
 ====
 
+== Assertion
+
+=== Assert Nil [[assert-nil]]
+
+Use `assert_nil` if expecting `nil`.
+
+[source,ruby]
+----
+# bad
+assert_equal(nil, actual)
+
+# good
+assert_nil(actual)
+----
+
 == Contributing
 
 The guide is still a work in progress - some guidelines are lacking examples, some guidelines don't have examples that illustrate them clearly enough.


### PR DESCRIPTION
Use `assert_nil` if expecting `nil`.

```ruby
# bad
assert_equal(nil, actual)

# good
assert_nil(actual)
```

This rule prevents the following MT6's deprecated warning:

```ruby
class ExampleTest < Minitest::Test
  def test_expecting_nil
    foo = nil

    assert_equal(nil, foo)
  end
end
```

```console
% bundle exec rake test
Run options: --seed 16727

# Running:

DEPRECATED: Use assert_nil if expecting nil from
/Users/koic/src/github.com/rubocop-hq/rubocop-minitest/test/rubocop/minitest_test.rb:13. This
will fail in Minitest 6.
```

https://github.com/seattlerb/minitest/blob/ab39d35fb4e84eb866ed9c4ecb707cbf3889de42/lib/minitest/assertions.rb#L203