### PR TITLE
Added style guide for assert true values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ assert_equal("rubocop-minitest", actual)
 
 === Assert Truthy [[assert-truthy]]
 
-Use `assert` if expecting `true` value instead of `assert_equal`.
+Use `assert` if expecting truthy value.
 
 [source,ruby]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,19 @@ assert_equal(actual, "rubocop-minitest")
 assert_equal("rubocop-minitest", actual)
 ----
 
+=== Assert Truthy [[assert-truthy]]
+
+Use `assert` if expecting `true` value instead of `assert_equal`.
+
+[source,ruby]
+----
+# bad
+assert_equal(true, actual)
+
+# good
+assert(actual)
+----
+
 == Contributing
 
 The guide is still a work in progress - some guidelines are lacking examples, some guidelines don't have examples that illustrate them clearly enough.


### PR DESCRIPTION
Sometimes I have seen developers making the mistake of using `assert_equal` to assert the boolean values. Adding cop to warn or correct this scenario would be nice. 