### PR TITLE
Added style for assert float values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -110,10 +110,24 @@ Use `assert_includes` to assert if the actual value is included in the collectio
 
 [source,ruby]
 ----
+# bad
 assert(collection.includes?(actual))
 
 # good
 assert_includes(collection, actual)
+----
+
+=== Assert In Delta [[assert-in-delta]]
+
+Use `assert_in_delta` if expecting `floats`.
+
+[source,ruby]
+----
+# bad
+assert_equal(Math::PI, actual)
+
+# good
+assert_in_delta(Math::PI, actual, 0.01)
 ----
 
 == Contributing


### PR DESCRIPTION
The documentation suggests using `assert_in_delta` when expecting float values -> https://github.com/seattlerb/minitest/blob/master/lib/minitest/assertions.rb#L188

I have never used but I thought let's open a PR for discussion atleast. This stackover links explains nicely -> https://stackoverflow.com/questions/39743448/what-is-the-difference-between-minitests-assert-in-delta-and-assert-in-epsilon