### PR TITLE
Add style guide for assert includes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,18 @@ assert_equal(true, actual)
 assert(actual)
 ----
 
+=== Assert Includes [[assert-includes]]
+
+Use `assert-includes` to assert if the actual value is included in the collection.
+
+[source,ruby]
+----
+assert(collection.includes?(actual))
+
+# good
+assert_includes(collection, actual)
+----
+
 == Contributing
 
 The guide is still a work in progress - some guidelines are lacking examples, some guidelines don't have examples that illustrate them clearly enough.


### PR DESCRIPTION
I saw it in one of the Rails PR. Test case for includes was added like `assert(collection.includes?(actual))` I am not able to find that PR but I think it is worth to add a cop to correct this scenario.