### PR TITLE
Added style guide for refute_nil values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,20 @@ assert_equal(nil, actual)
 assert_nil(actual)
 ----
 
+=== Assert Not Nil [[refute-nil]]
+
+Use `refute_nil` or `assert_not_nil` if not expecting `nil`. `assert_not_nil` is a alias to `refute_nil` which is only available in Rails projects.
+
+[source,ruby]
+----
+# bad
+assert(actual.nil?)
+
+# good
+refute_nil(actual)
+assert_not_nil(actual)
+----
+
 === Assert Equal Arguments Order[[assert-equal-args-order]]
 
 `assert_equal` should always have expected value as first argument because if the assertion fails the

--- a/README.adoc
+++ b/README.adoc
@@ -61,9 +61,9 @@ assert_equal(nil, actual)
 assert_nil(actual)
 ----
 
-=== Assert Not Nil [[refute-nil]]
+=== Refute Nil [[refute-nil]]
 
-Use `refute_nil` or `assert_not_nil` if not expecting `nil`. `assert_not_nil` is a alias to `refute_nil` which is only available in Rails projects.
+Use `refute_nil` if not expecting `nil`.
 
 [source,ruby]
 ----
@@ -72,7 +72,6 @@ assert(actual.nil?)
 
 # good
 refute_nil(actual)
-assert_not_nil(actual)
 ----
 
 === Assert Equal Arguments Order[[assert-equal-args-order]]


### PR DESCRIPTION
I wanted to open this for discussion since Rails adds alias for all the `refute_` test case helper methods. Here is Rails code which adds alias to all the refute method https://github.com/rails/rails/blob/master/activesupport/lib/active_support/test_case.rb#L146-L159