### PR TITLE
Fixed the refute_nil bad example case

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,7 +68,8 @@ Use `refute_nil` if not expecting `nil`.
 [source,ruby]
 ----
 # bad
-assert(actual.nil?)
+assert(!actual.nil?)
+refute(actual.nil?)
 
 # good
 refute_nil(actual)


### PR DESCRIPTION
Fixes comment https://github.com/rubocop-hq/minitest-style-guide/pull/9/files#r315066207