### PR TITLE
Fix a typo for assert includes and refute includes rules

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -139,7 +139,7 @@ Use `assert_includes` to assert if the actual value is included in the collectio
 [source,ruby]
 ----
 # bad
-assert(collection.includes?(actual))
+assert(collection.include?(actual))
 
 # good
 assert_includes(collection, actual)
@@ -152,8 +152,8 @@ Use `refute_includes` if the actual value is not included in the collection.
 [source,ruby]
 ----
 # bad
-refute(collection.includes?(actual))
-assert(!collection.includes?(actual))
+refute(collection.include?(actual))
+assert(!collection.include?(actual))
 
 # good
 refute_includes(collection, actual)


### PR DESCRIPTION
This PR fixes a typo for assert includes an refute includes rules.

`assert_includes` and `refute_includes` methods assert using `include` instead of `includes`.

- https://github.com/seattlerb/minitest/blob/930ec0ba2e3ca010cca388a0429b33fd63c7d0bd/lib/minitest/assertions.rb#L239-L248
- https://github.com/seattlerb/minitest/blob/930ec0ba2e3ca010cca388a0429b33fd63c7d0bd/lib/minitest/assertions.rb#L615-L624