### PR TITLE
Use `==` method instead of `eql?` method for "Refute Equal" rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -107,8 +107,8 @@ Use `refute_equal` if `expected` and `actual` should not be same.
 [source,ruby]
 ----
 # bad
-assert(!"rubocop-minitest".eql?(actual))
 assert("rubocop-minitest" != actual)
+assert(!"rubocop-minitest" == (actual))
 
 # good
 refute_equal("rubocop-minitest", actual)


### PR DESCRIPTION
`refute_equal` method uses `==` method, not `eql?` method.
https://github.com/seattlerb/minitest/blob/15ed8e4/lib/minitest/assertions.rb#L587-L592

`==` method and `eql?` method behave differently.

This PR will remove `eql?` method to maintain compatibility for bad case and good case behavior.