### PR TITLE
[Fix #25] Add global expectations rule

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -352,6 +352,29 @@ refute('rubocop-minitest'.kind_of?(String))
 refute_kind_of(String, 'rubocop-minitest')
 ----
 
+== Expectations
+
+This section discusses idiomatic usage of the expectations provided by Minitest.
+
+=== Global Expectations [[global-expectations]]
+
+Use `_()` wrapper if using global expectations which are deprecated methods.
+
+[source,ruby]
+----
+# bad
+do_something.must_equal 2
+{ raise_exception }.must_raise TypeError
+
+# good
+_(do_something).must_equal 2
+value(do_something).must_equal 2
+expect(do_something).must_equal 2
+_ { raise_exception }.must_raise TypeError
+----
+
+Check the http://docs.seattlerb.org/minitest/Minitest/Expectations.html[Minitest::Expectations doc] for more information about its usage.
+
 == Related Guides
 
 * https://rubystyle.guide[Ruby Style Guide]


### PR DESCRIPTION
Fixes #25.

This PR adds global expectations rule.

It separates the problems solved by The Style Guide and RuboCop Minitest respectively.

## The Minitest Style Guide

This will be already solved by https://github.com/rubocop-hq/rubocop-minitest/pull/63.

```ruby
# bad
(1+1).must_equal 2

# good
_(1 + 1).must_equal 2
value(1 + 1).must_equal 2
expect(1 + 1).must_equal 2
```

## RuboCop Minitest

This will be implemented as a different Minitest cop than https://github.com/rubocop-hq/rubocop-minitest/pull/63.

```ruby
# default
_(1 + 1).must_equal 2      # good
value(1 + 1).must_equal 2  # bad
expect(1 + 1).must_equal 2 # bad

# optional (value)
_(1 + 1).must_equal 2      # bad
value(1 + 1).must_equal 2  # good
expect(1 + 1).must_equal 2 # bad

# optional (expect)
_(1 + 1).must_equal 2      # bad
value(1 + 1).must_equal 2  # bad
expect(1 + 1).must_equal 2 # good
```

This PR focuses on the issues that The Style Guide should solve.