### PR TITLE
Add RSpec comparison for expected/actual ordering

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,6 +93,8 @@ refute_nil(actual)
 `assert_equal` should always have expected value as first argument because if the assertion fails the
 error message would say expected "rubocop-minitest" received "rubocop" not the other way around.
 
+NOTE: If you're used to working with RSpec then this in the opposite order.
+
 [source,ruby]
 ----
 # bad


### PR DESCRIPTION
I've noticed that it's common to get this backwards if you're used to RSpec.